### PR TITLE
Add CNAME file pointing to eastwind.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+eastwind.org


### PR DESCRIPTION
I think this might fix your redirects from the `www` subdomain.

But maybe I'm missing something because I'm not sure how github knows how to handle http://eastwind.org correctly.

I think you may have to update your DNS `A` record for `eastwind.org` as well, according to this link it should point to `192.30.252.153` & `192.30.252.154`: https://help.github.com/articles/tips-for-configuring-an-a-record-with-your-dns-provider/
